### PR TITLE
Refactoring, short-circuiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+[Change log file format](http://keepachangelog.com/)
+
+## [1.2.0] - 2016-04-26
+### Added
+- `launchScreenDelay` option
+- tests

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 More control over hot code push reloading for your mobile apps. A replacement for [`mdg:reload-on-resume`](https://github.com/meteor/mobile-packages/blob/master/packages/mdg:reload-on-resume/README.md) with more options and better UX.
 
 As of Meteor 1.3, if you prevent instant reloading on updates, the newest version of the code will be used on your app's next cold start - no reload necessary. This can be achieved with `Reloader.configure({check: false, refresh: 'start'})`. However, you can also:
-- Reload on resume, to update to the newest version of the code when the app is returned from the background: see [`refresh`](#refresh) (the launch screen it put back up during such reloads to hide the white screen you get with `mdg:reload-on-resume`)
+- Reload on resume, to update to the newest version of the code when the app is returned from the background: see [`refresh`](#refresh) (the launch screen is put back up during such reloads to hide the white screen you get with `mdg:reload-on-resume`)
 - On start or resume, leave the launch screen up and wait to see whether there is an update available: see [`check`](#check), [`checkTimer`](#checktimer), and [`idleCutoff`](#idlecutoff)
 - Delay removal of the launch screen, to hide the white screen that appears at the beginning of a reload: see [`launchScreenDelay`](#launchscreendelay)
 
@@ -21,7 +21,7 @@ As of Meteor 1.3, if you prevent instant reloading on updates, the newest versio
   - [Reloader.reload()](#reloaderreload)
   - [reloader-update](#reloader-update)
 
-## Installation
+### Installation
 
 `meteor add jamielob:reloader`
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Reloader
 
-More control over hot code push reloading for your mobile apps. A replacement for `[mdg:reload-on-resume](https://github.com/meteor/mobile-packages/blob/master/packages/mdg:reload-on-resume/README.md)` with more options and better UX.
+More control over hot code push reloading for your mobile apps. A replacement for [`mdg:reload-on-resume`](https://github.com/meteor/mobile-packages/blob/master/packages/mdg:reload-on-resume/README.md) with more options and better UX.
 
 As of Meteor 1.3, if you prevent instant reloading on updates, the newest version of the code will be used on your app's next cold start - no reload necessary. This can be achieved with `Reloader.configure({check: false, refresh: 'start'})`. However, you can also:
-- Reload on resume, to update to the newest version of the code when the app is returned from the background: see `[refresh](#refresh)` (the launch screen it put back up during such reloads to hide the white screen you get with `mdg:reload-on-resume`)
-- On start or resume, leave the launch screen up and wait to see whether there is an update available: see [`check`](#check), `[checkTimer](#checktimer)`, and `[idleCutoff](#idlecutoff)`
-- Delay removal of the launch screen, to hide the white screen that appears at the beginning of a reload: see `[launchScreenDelay](#launchscreendelay)`
+- Reload on resume, to update to the newest version of the code when the app is returned from the background: see [`refresh`](#refresh) (the launch screen it put back up during such reloads to hide the white screen you get with `mdg:reload-on-resume`)
+- On start or resume, leave the launch screen up and wait to see whether there is an update available: see [`check`](#check), [`checkTimer`](#checktimer), and [`idleCutoff`](#idlecutoff)
+- Delay removal of the launch screen, to hide the white screen that appears at the beginning of a reload: see [`launchScreenDelay`](#launchscreendelay)
 
 
 - [Configure](#configure)
@@ -28,7 +28,7 @@ If you have any calls to `location.reload()` or `location.replace(location.href)
 
 ## Configure
 
-The default options are shown below. You can override them anywhere in your `client/lib` folder.
+The default options are shown below. You can override them anywhere in your `client/` folder.
 
 ```
 Reloader.configure({
@@ -101,11 +101,13 @@ Template.post.onRendered(() => {
 });
 ```
 
+Or if you have a layout template, you could put a single `.release()` in that template's `onRendered`.
+
 ## Helpers
 
 These helpers can help you to have an "Update Now" button.
 
-#### A note about using these helpers
+### A note about using these helpers
 Some people have reported having their app rejected during the Apple review process for having an "Update Now" button or similar as opposed to using the refresh on resume behavior that this package provides by default.  If you really want to have an update button when new code is available, make sure you don't push any new code to the server until after your app has been approved. But it's probably safer/better to simply not have an update button at all!
 
 ### How to use them anyway

--- a/README.md
+++ b/README.md
@@ -1,14 +1,33 @@
 # Reloader
 
-More control over hot code push reloading for your production apps.   Designed to replace `mdg:reload-on-resume` and provide a more production-ready approach.
+More control over hot code push reloading for your mobile apps. A replacement for `[mdg:reload-on-resume](https://github.com/meteor/mobile-packages/blob/master/packages/mdg:reload-on-resume/README.md)` with more options and better UX.
+
+As of Meteor 1.3, if you prevent instant reloading on updates, the newest version of the code will be used on your app's next cold start - no reload necessary. This can be achieved with `Reloader.configure({check: false, refresh: 'start'})`. However, you can also:
+- Reload on resume, to update to the newest version of the code when the app is returned from the background: see `[refresh](#refresh)` (the launch screen it put back up during such reloads to hide the white screen you get with `mdg:reload-on-resume`)
+- On start or resume, leave the launch screen up and wait to see whether there is an update available: see `[check](#check)`, `[checkTimer](#checktimer)`, and `[idleCutoff](#idlecutoff)`
+- Delay removal of the launch screen, to hide the white screen that appears at the beginning of a reload: see `[launchScreenDelay](#launchscreendelay)`
+
+- [Configure](#configure)
+  - [check](#check)
+  - [checkTimer](#checkTimer)
+  - [refresh](#refresh)
+  - [idleCutoff](#idlecutoff)
+  - [launchScreenDelay](#launchscreendelay)
+- [Helpers](#helpers)
+  - [Reloader.updateAvailable.get()]
+  - [{{updateAvailable}}]
+  - [Reloader.reload()]
+  - [reloader-update](#reloader-update)
 
 ## Installation
 
 `meteor add jamielob:reloader`
 
-## Setup
+If you have any calls to `location.reload()` or `location.replace(location.href)` in your app, replace them with `Reloader.reload()`.
 
-No setup required, just add the package.  The default options are shown below. You can override them anywhere in your `client/lib` folder.
+## Configure
+
+The default options are shown below. You can override them anywhere in your `client/lib` folder.
 
 ```
 Reloader.configure({
@@ -16,6 +35,7 @@ Reloader.configure({
 	checkTimer: 3000,  // Wait 3 seconds to see if new code is available
 	refresh: 'startAndResume', // Refresh to already downloaded code on both start and resume
 	idleCutoff: 1000 * 60 * 10  // Wait 10 minutes before treating a resume as a start
+    launchScreenDelay: 100 // After reload, wait 100ms before hiding the launch screen
 });
 ```
 
@@ -38,40 +58,58 @@ This will make sure the first time your app is run it is up to date, will downlo
 
 When to make additional checks for new code bundles. The app splash screen is shown during the check. Possible values are:
 
-- `everyStart`: Check every time the app starts.  Does not include resuming the app, unless the `idleCutOff` has been reached.
+- `everyStart` (default): Check every time the app starts.  Does not include resuming the app, unless the `idleCutOff` has been reached.
 - `firstStart`: Check only the first time the app starts (just after downloading it).
 - `false`: Never make additional checks and rely purely on code bundles being downlaoded in the background while the app is being used.
 
 ### checkTimer
 
-How long to wait (in ms) when making additional checks for new file bundles. In future versions of Meteor we will have an API to instantly check if an update is available or not, but until then we need to simply wait to see if a new code bundle is downloaded.  Extend this if you find that you have new code immediately after starting the app.
+Default: `3000`
+
+How long to wait (in ms) when making additional checks for new file bundles. In future versions of Meteor we will have an API to instantly check if an update is available or not, but until then we need to simply wait to see if a new code bundle is downloaded. Depending on the size of your app bundle and the phone's connection speed, the default three seconds may not be enough - you can increase it if you find that you have new code immediately after starting the app.
 
 ### refresh
 
 When to refresh to the latest code bundle if one was downloaded while using the app.  The app splash screen is shown during the refresh. Possible values are:
 
-- `startAndResume`: Refresh to the latest bundle both when starting and resuming the app.
+- `startAndResume` (default): Refresh to the latest bundle both when starting and resuming the app.
 - `start`: Refresh only when the app is started (not resumed).
 - `instantly`: Overrides everything else.  If set, your app will have similar behaviour to the default in Meteor, with code updates being refreshed immeidately. The only improvement/difference is that the app's splash screen is displayed during the refresh.
 
-
-
-
 ### idleCutoff
 
-How long (in ms) can an app be idle before we consider it a start and not a resume.  Set to `0` to never do an additional check on resume.
+Default: `1000 * 60 * 10 // 10 minutes`
 
+How long (in ms) can an app be idle before we consider it a start and not a resume. Applies only when `check: 'everyStart'`. Set to `0` to never check on resume.
 
+### launchScreenDelay
 
+Default: `100`
+
+How long to wait (in ms) after reload before hiding the launch screen. The goal is to leave it up until your page has finished rendering, so the user does not see a blank white screen. The duration will vary based on your app's render time and the speed of the device. To be more precise, set `launchScreenDelay` to 0 and release the launch screen yourself when the page has rendered. For example, if the only two pages that might be displayed on reload are `index` and `post`, then you would do:
+
+```javascript
+launchScreenHandle = Launchscreen.hold()
+
+Template.index.onRendered(() => {
+  launchScreenHandle.release()
+});
+
+Template.post.onRendered(() => {
+  launchScreenHandle.release()
+});
+```
 
 ## Helpers
 
 These helpers can help you to have an "Update Now" button.
 
-#### A note about using these helpers ####
+#### A note about using these helpers
 Some people have reported having their app rejected during the Apple review process for having an "Update Now" button or similar as opposed to using the refresh on resume behavior that this package provides by default.  If you really want to have an update button when new code is available, make sure you don't push any new code to the server until after your app has been approved. But it's probably safer/better to simply not have an update button at all!
 
-#### How to use them anyway ####
+### How to use them anyway
+
+#### Reloader.updateAvailable.get()
 
 `Reloader.updateAvailable` is a reactive variable that returns true when an update has been downloaded.
 
@@ -79,7 +117,9 @@ Some people have reported having their app rejected during the Apple review proc
 Reloader.updateAvailable.get(); // Reactively returns true if an update is ready
 ```
 
-This package provides a template helper that retrieves the value of the reactiveVar easily.
+#### {{updateAvailable}}
+
+This package provides a Blaze template helper that retrieves the value of the reactiveVar easily.
 
 ```
 {{#if updateAvailable}}
@@ -87,7 +127,13 @@ This package provides a template helper that retrieves the value of the reactive
 {{/if}}
 ```
 
-It also provides an easy reload event that you can attach to a button that will briefly show the splash screen and update to the latest version. Simply add the `reloader-update` attribute to a button.
+#### Reloader.reload()
+
+Call `Reloader.reload()` to refresh the page.
+
+#### reloader-update
+
+This package also provides an easy reload event that you can attach to a button that will briefly show the splash screen and update to the latest version. Simply add the `reloader-update` attribute to a button.
 
 ```
 {{#if updateAvailable}}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ As of Meteor 1.3, if you prevent instant reloading on updates, the newest versio
   - [{{updateAvailable}}](#updateavailable)
   - [Reloader.reload()](#reloaderreload)
   - [reloader-update](#reloader-update)
+- [Development](#development)
+  - [Run tests](#run-tests)
+  - [Credits](#credits)
 
 ### Installation
 
@@ -117,7 +120,7 @@ Some people have reported having their app rejected during the Apple review proc
 
 `Reloader.updateAvailable` is a reactive variable that returns true when an update has been downloaded.
 
-```
+```js
 Reloader.updateAvailable.get(); // Reactively returns true if an update is ready
 ```
 
@@ -125,7 +128,7 @@ Reloader.updateAvailable.get(); // Reactively returns true if an update is ready
 
 This package provides a Blaze template helper that retrieves the value of the reactiveVar easily.
 
-```
+```html
 {{#if updateAvailable}}
   	<p>Update available!</p>
 {{/if}}
@@ -139,11 +142,25 @@ Call `Reloader.reload()` to refresh the page.
 
 This package also provides an easy reload event that you can attach to a button that will briefly show the splash screen and update to the latest version. Simply add the `reloader-update` attribute to a button.
 
-```
+```html
 {{#if updateAvailable}}
 	<a class="button" reloader-update>Tap here to update!</a>
 {{/if}}
 ```
 
+## Development
 
+### Run tests
 
+```bash
+git clone git@github.com:jamielob/reloader.git
+cd reloader
+meteor test-packages ./ --driver-package practicalmeteor:mocha
+open localhost:3000
+```
+
+### Credits
+
+[Contributors](https://github.com/jamielob/reloader/graphs/contributors)
+
+And thanks to @martijnwalraven for his help with this packages and superb work on Meteor Cordova! 👏

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ As of Meteor 1.3, if you prevent instant reloading on updates, the newest versio
 - On start or resume, leave the launch screen up and wait to see whether there is an update available: see [`check`](#check), [`checkTimer`](#checktimer), and [`idleCutoff`](#idlecutoff)
 - Delay removal of the launch screen, to hide the white screen that appears at the beginning of a reload: see [`launchScreenDelay`](#launchscreendelay)
 
+### Contents
 
 - [Configure](#configure)
   - [check](#check)

--- a/README.md
+++ b/README.md
@@ -4,19 +4,20 @@ More control over hot code push reloading for your mobile apps. A replacement fo
 
 As of Meteor 1.3, if you prevent instant reloading on updates, the newest version of the code will be used on your app's next cold start - no reload necessary. This can be achieved with `Reloader.configure({check: false, refresh: 'start'})`. However, you can also:
 - Reload on resume, to update to the newest version of the code when the app is returned from the background: see `[refresh](#refresh)` (the launch screen it put back up during such reloads to hide the white screen you get with `mdg:reload-on-resume`)
-- On start or resume, leave the launch screen up and wait to see whether there is an update available: see `[check](#check)`, `[checkTimer](#checktimer)`, and `[idleCutoff](#idlecutoff)`
+- On start or resume, leave the launch screen up and wait to see whether there is an update available: see [`check`](#check), `[checkTimer](#checktimer)`, and `[idleCutoff](#idlecutoff)`
 - Delay removal of the launch screen, to hide the white screen that appears at the beginning of a reload: see `[launchScreenDelay](#launchscreendelay)`
+
 
 - [Configure](#configure)
   - [check](#check)
-  - [checkTimer](#checkTimer)
+  - [checkTimer](#checktimer)
   - [refresh](#refresh)
   - [idleCutoff](#idlecutoff)
   - [launchScreenDelay](#launchscreendelay)
 - [Helpers](#helpers)
-  - [Reloader.updateAvailable.get()]
-  - [{{updateAvailable}}]
-  - [Reloader.reload()]
+  - [Reloader.updateAvailable.get()](#reloaderupdateavailableget)
+  - [{{updateAvailable}}](#updateavailable)
+  - [Reloader.reload()](#reloaderreload)
   - [reloader-update](#reloader-update)
 
 ## Installation

--- a/package.js
+++ b/package.js
@@ -14,6 +14,7 @@ Package.onUse(function(api) {
   api.versionsFrom('1.3.1');
   api.use('ecmascript');
   api.use('check');
+  api.use('underscore', 'web.cordova');
   api.use('reload', 'web.cordova');
   api.use('templating', 'web.cordova');
   api.use('reactive-var', 'web.cordova');

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'jamielob:reloader',
-  version: '1.1.5',
+  version: '1.2.0',
   summary: 'More control over hot code push reloading',
   git: 'https://github.com/jamielob/reloader/',
   documentation: 'README.md'
@@ -19,22 +19,20 @@ Package.onUse(function(api) {
            'reload',
            'templating',
            'reactive-var',
-           'tracker'], 'client');
-
-  // So that the app can reference LaunchScreen
-  api.imply('launch-screen', 'client');
+           'tracker',
+           'launch-screen'], 'client');
 
   api.mainModule('reloader.js', 'client');
 
   api.export('Reloader', 'client');
 });
 
+// No way to make this only happen onTest
+Npm.depends({
+  sinon: '1.17.3'
+});
 
 Package.onTest(function(api) {
-  Npm.depends({
-    sinon: '1.17.3'
-  });
-
   api.use('jamielob:reloader', 'client')
 
   api.use(['ecmascript',

--- a/package.js
+++ b/package.js
@@ -20,7 +20,7 @@ Package.onUse(function(api) {
   api.use('reactive-var', 'web.cordova');
   api.use('tracker', 'web.cordova');
 
-  // So that the app can reference Launchscreen
+  // So that the app can reference LaunchScreen
   api.imply('launch-screen', 'client');
 
   api.mainModule('reloader.js', 'web.cordova');

--- a/package.js
+++ b/package.js
@@ -18,7 +18,9 @@ Package.onUse(function(api) {
   api.use('reload', 'web.cordova');
   api.use('templating', 'web.cordova');
   api.use('reactive-var', 'web.cordova');
+  api.use('tracker', 'web.cordova');
 
+  // So that the app can reference Launchscreen
   api.imply('launch-screen', 'client');
 
   api.mainModule('reloader.js', 'web.cordova');

--- a/package.js
+++ b/package.js
@@ -26,5 +26,19 @@ Package.onUse(function(api) {
   api.mainModule('reloader.js', 'web.cordova');
 
   api.export('Reloader');
+});
 
+
+Package.onTest(function(api) {
+  Npm.depends({
+    sinon: '1.17.3'
+  });
+
+  api.use('jamielob:reloader')
+
+  api.use(['ecmascript',
+           'underscore',
+           'practicalmeteor:mocha']);
+
+  api.mainModule('reloader-tests.js');
 });

--- a/package.js
+++ b/package.js
@@ -12,20 +12,21 @@ Cordova.depends({
 
 Package.onUse(function(api) {
   api.versionsFrom('1.3.1');
-  api.use('ecmascript');
-  api.use('check');
-  api.use('underscore', 'web.cordova');
-  api.use('reload', 'web.cordova');
-  api.use('templating', 'web.cordova');
-  api.use('reactive-var', 'web.cordova');
-  api.use('tracker', 'web.cordova');
+
+  api.use(['ecmascript',
+           'check',
+           'underscore',
+           'reload',
+           'templating',
+           'reactive-var',
+           'tracker'], 'client');
 
   // So that the app can reference LaunchScreen
   api.imply('launch-screen', 'client');
 
-  api.mainModule('reloader.js', 'web.cordova');
+  api.mainModule('reloader.js', 'client');
 
-  api.export('Reloader');
+  api.export('Reloader', 'client');
 });
 
 
@@ -34,11 +35,11 @@ Package.onTest(function(api) {
     sinon: '1.17.3'
   });
 
-  api.use('jamielob:reloader')
+  api.use('jamielob:reloader', 'client')
 
   api.use(['ecmascript',
            'underscore',
-           'practicalmeteor:mocha']);
+           'practicalmeteor:mocha'], 'client');
 
-  api.mainModule('reloader-tests.js');
+  api.mainModule('reloader-tests.js', 'client');
 });

--- a/package.js
+++ b/package.js
@@ -18,7 +18,8 @@ Package.onUse(function(api) {
   api.use('reload', 'web.cordova');
   api.use('templating', 'web.cordova');
   api.use('reactive-var', 'web.cordova');
-  api.use('launch-screen', 'web.cordova');
+
+  api.imply('launch-screen', 'client');
 
   api.mainModule('reloader.js', 'web.cordova');
 

--- a/package.js
+++ b/package.js
@@ -1,12 +1,8 @@
 Package.describe({
   name: 'jamielob:reloader',
   version: '1.1.5',
-  // Brief, one-line summary of the package.
   summary: 'More control over hot code push reloading',
-  // URL to the Git repository containing the source code for this package.
   git: 'https://github.com/jamielob/reloader/',
-  // By default, Meteor will default to using README.md for documentation.
-  // To avoid submitting documentation, set this field to null.
   documentation: 'README.md'
 });
 

--- a/reloader-tests.js
+++ b/reloader-tests.js
@@ -1,7 +1,16 @@
-console.log('Reloader', Reloader)
+// NOTE: I think our Reload._onMigrate messes with test app reloading?
+// See "Cannot read property '0' of undefined" in browser console
+// after editing the code
+//
+// In order to get test output to update, you may need to
+// click the "refresh" header
 
 import { _ } from 'meteor/underscore';
+
+// http://chaijs.com/api/assert/
 import { assert } from 'meteor/practicalmeteor:chai';
+
+// http://sinonjs.org/
 import sinon from 'sinon'
 
 describe('refresh', function() {
@@ -12,16 +21,17 @@ describe('refresh', function() {
 
   describe('startAndResume', function() {
 
-    Reloader.configure({
-      refresh: 'startAndResume'
-    })
-   
+    before(function() {
+      Reloader.configure({
+        refresh: 'startAndResume'
+      })
+    });
+
     it('reloads on resume when update is available', function() {
       Reloader.updateAvailable.set(true);
 
       Reloader._onResume();
-      
-      assert.isTrue(Reload.reload.called);
+      assert.isTrue(Reloader.reload.called);
     });
 
     it("doesn't reload on resume when update isn't available", function() {
@@ -29,34 +39,26 @@ describe('refresh', function() {
 
       Reloader._onResume();
       
-      assert.isFalse(Reload.reload.called);
-    });
-
-    it('reloads on start when update is available', function() {
-      Reloader.updateAvailable.set(true);
-
-      Reloader._onPageLoad();
-      
-      assert.isTrue(Reload.reload.called);
+      assert.isFalse(Reloader.reload.called);
     });
 
   })
 
   describe('start', function() {
 
-    Reloader.configure({
-      refresh: 'start'
-    })
+    before(function() {
+      Reloader.configure({
+        refresh: 'start'
+      })
+    });
 
     it("doesn't reload on resume when update is available", function() {
       Reloader.updateAvailable.set(true);
 
       Reloader._onResume();
       
-      assert.isFalse(Reload.reload.called);
+      assert.isFalse(Reloader.reload.called);
     });
-
-    // todo
 
   });
 })
@@ -64,3 +66,4 @@ describe('refresh', function() {
 describe('check', function() {
   // should call / not call _checkForUpdate
 })
+

--- a/reloader-tests.js
+++ b/reloader-tests.js
@@ -1,6 +1,4 @@
-console.log('Reloader 1', Reloader)
-import {Reloader} from 'meteor/jamielob:reloader'
-console.log('Reloader 2', Reloader)
+console.log('Reloader', Reloader)
 
 import { _ } from 'meteor/underscore';
 import { assert } from 'meteor/practicalmeteor:chai';

--- a/reloader-tests.js
+++ b/reloader-tests.js
@@ -1,0 +1,68 @@
+console.log('Reloader 1', Reloader)
+import {Reloader} from 'meteor/jamielob:reloader'
+console.log('Reloader 2', Reloader)
+
+import { _ } from 'meteor/underscore';
+import { assert } from 'meteor/practicalmeteor:chai';
+import sinon from 'sinon'
+
+describe('refresh', function() {
+
+  beforeEach(function() {
+    Reloader.reload = sinon.spy(); // todo save original and repair if needed later
+  });
+
+  describe('startAndResume', function() {
+
+    Reloader.configure({
+      refresh: 'startAndResume'
+    })
+   
+    it('reloads on resume when update is available', function() {
+      Reloader.updateAvailable.set(true);
+
+      Reloader._onResume();
+      
+      assert.isTrue(Reload.reload.called);
+    });
+
+    it("doesn't reload on resume when update isn't available", function() {
+      Reloader.updateAvailable.set(false);
+
+      Reloader._onResume();
+      
+      assert.isFalse(Reload.reload.called);
+    });
+
+    it('reloads on start when update is available', function() {
+      Reloader.updateAvailable.set(true);
+
+      Reloader._onPageLoad();
+      
+      assert.isTrue(Reload.reload.called);
+    });
+
+  })
+
+  describe('start', function() {
+
+    Reloader.configure({
+      refresh: 'start'
+    })
+
+    it("doesn't reload on resume when update is available", function() {
+      Reloader.updateAvailable.set(true);
+
+      Reloader._onResume();
+      
+      assert.isFalse(Reload.reload.called);
+    });
+
+    // todo
+
+  });
+})
+
+describe('check', function() {
+  // should call / not call _checkForUpdate
+})

--- a/reloader.js
+++ b/reloader.js
@@ -221,3 +221,6 @@ Template.registerHelper("updateAvailable", function() {
 $(document).on('click', '[reloader-update]', function(event) {
 	Reloader.reload();
 });
+
+
+export Reloader

--- a/reloader.js
+++ b/reloader.js
@@ -1,3 +1,5 @@
+const launchScreen = LaunchScreen.hold();
+
 Reloader = {
 
 	_options: {},
@@ -19,7 +21,171 @@ Reloader = {
 		_.extend(this._options, options);
 	},
 
-  updateAvailable: new ReactiveVar(false)
+  updateAvailable: new ReactiveVar(false),
+
+	reload() {
+		// Show the splashscreen
+		navigator.splashscreen.show();
+
+		// Set the refresh flag
+		localStorage.setItem('reloaderWasRefreshed', Date.now());
+
+		// Reload the page
+		window.location.replace(window.location.href);
+	},
+
+
+	// Either everyStart is set OR firstStart is set and it's our first start
+	_shouldCheckForUpdate() {
+		this._options.check === 'everyStart' ||
+			(
+				this._options.check === 'firstStart' &&
+					!localStorage.getItem('reloaderLastStart')
+			)
+	},
+
+
+	_onPageLoad() {
+		// If this was a refresh, just release the launchscreen (after a short delay to hide the white flash)
+		if ( localStorage.getItem('reloaderWasRefreshed') ) {
+
+			Meteor.setTimeout(function() {
+
+				launchScreen.release();
+
+				// Reset the reloaderWasRefreshed flag
+				localStorage.removeItem('reloaderWasRefreshed');
+
+			}, Reloader._options.launchScreenDelay); // Short delay helps with white flash
+
+			// Otherwise this should be treated as a cold start
+		} else {
+
+			if (shouldCheckForUpdate()) {
+
+				// Check if we have a HCP after the check timer is up
+				Meteor.setTimeout(function() {
+
+					// If there is a new version available
+					if (Reloader.updateAvailable.get()) {
+
+						// Reset the new version flag
+						Reloader.updateAvailable.set(false);
+
+						// Set the refresh flag
+						localStorage.setItem('reloaderWasRefreshed', Date.now());
+
+						// Reload the page
+						window.location.replace(window.location.href);
+						
+					} else {
+
+						// Just release the splash screen
+						launchScreen.release();
+
+					}
+					
+
+				}, Reloader._options.checkTimer );
+
+			} else {
+
+				// Otherwise just relase the splash screen
+				launchScreen.release();
+
+			}
+
+		}
+	},
+
+	_onResume() {
+		// Grab the last time we paused
+		const lastPause = Number(localStorage.getItem('reloaderLastPause'));
+
+		// Calculate the cutoff timestamp
+		const idleCutoffAt = Number( Date.now() - Reloader._options.idleCutoff );
+
+		// Check if the idleCutoff is set AND we exceeded the idleCutOff limit AND the everyStart check is set
+		if ( Reloader._options.idleCutoff && lastPause < idleCutoffAt && Reloader._options.check === 'everyStart') {
+
+			// Show the splashscreen
+			navigator.splashscreen.show();
+
+			// Check if we have a HCP after the check timer is up
+			Meteor.setTimeout(function() {
+
+				// If there is a new version available
+				if (Reloader.updateAvailable.get()) {
+
+					// Reset the new version flag
+					Reloader.updateAvailable.set(false);
+
+					// Set the refresh flag
+					localStorage.setItem('reloaderWasRefreshed', Date.now());
+
+					// Reload the page
+					window.location.replace(window.location.href);
+					
+				} else {
+
+					// Hide the splashscreen
+					navigator.splashscreen.hide();
+
+				}
+				
+
+			}, Reloader._options.checkTimer);
+
+
+			// If we don't need to do an additional check
+		} else {
+
+			// Check if there's a new version available already AND we need to refresh on resume
+			if ( Reloader.updateAvailable.get() && Reloader._options.refresh === 'startAndResume' ) {
+
+	  		// Show the splashscreen
+				navigator.splashscreen.show();
+
+	  		// Reset the new version flag
+				Reloader.updateAvailable.set(false);
+
+	  		// Set the refresh flag
+				localStorage.setItem('reloaderWasRefreshed', Date.now());
+				
+				// Refresh
+				window.location.replace(window.location.href);
+
+			} 
+
+		}
+
+	},
+
+	_onMigrate() {
+		if (Reloader._options.refreshInstantly) {
+
+			// Show the splashscreen
+			navigator.splashscreen.show();
+
+			// Set the refresh flag
+			localStorage.setItem('reloaderWasRefreshed', Date.now());
+
+			// Reload the page
+			window.location.replace(window.location.href);
+
+			// return [true, {}];
+
+		} else {
+
+			// Set the flag
+			Reloader.updateAvailable.set(true);
+
+			// Don't refresh yet
+			return false;
+
+		}
+	}
+
 };
 
 // Set the defaults
@@ -32,139 +198,15 @@ Reloader.configure({
 });
 
 
-// Either everyStart is set OR firstStart is set and it's our first start
-const shouldCheckForUpdate = () => {
-	Reloader._options.check === 'everyStart' ||
-		(
-			Reloader._options.check === 'firstStart' &&
-			!localStorage.getItem('reloaderLastStart')
-		)
-};
-
-const launchScreen = LaunchScreen.hold();
-
-const lastPause = Number(localStorage.getItem('reloaderLastPause'));
-
-// If this was a refresh, just release the launchscreen (after a short delay to hide the white flash)
-if ( localStorage.getItem('reloaderWasRefreshed') ) {
-
-	Meteor.setTimeout(function() {
-
-		launchScreen.release();
-
-		// Reset the reloaderWasRefreshed flag
-		localStorage.removeItem('reloaderWasRefreshed');
-
-	}, Reloader._options.launchScreenDelay); // Short delay helps with white flash
-
-	// Otherwise this should be treated as a cold start
-} else {
-
-	if (shouldCheckForUpdate()) {
-
-		// Check if we have a HCP after the check timer is up
-		Meteor.setTimeout(function() {
-
-			// If there is a new version available
-			if (Reloader.updateAvailable.get()) {
-
-				// Reset the new version flag
-				Reloader.updateAvailable.set(false);
-
-				// Set the refresh flag
-				localStorage.setItem('reloaderWasRefreshed', Date.now());
-
-				// Reload the page
-				window.location.replace(window.location.href);
-				
-			} else {
-
-				// Just release the splash screen
-				launchScreen.release();
-
-			}
-			
-
-		}, Reloader._options.checkTimer );
-
-	} else {
-
-		// Otherwise just relase the splash screen
-		launchScreen.release();
-
-	}
-
-}
+Reloader._onPageLoad();
 
 // Set the last start flag
 localStorage.setItem('reloaderLastStart', Date.now());
 
-
 // Watch for the app resuming
 document.addEventListener("resume", function () {
-
-  	// Grab the last time we paused
-	const lastPause = Number(localStorage.getItem('reloaderLastPause'));
-
-	// Calculate the cutoff timestamp
-	const idleCutoffAt = Number( Date.now() - Reloader._options.idleCutoff );
-
-	// Check if the idleCutoff is set AND we exceeded the idleCutOff limit AND the everyStart check is set
-	if ( Reloader._options.idleCutoff && lastPause < idleCutoffAt && Reloader._options.check === 'everyStart') {
-
-		// Show the splashscreen
-		navigator.splashscreen.show();
-
-	  	// Check if we have a HCP after the check timer is up
-		Meteor.setTimeout(function() {
-
-			// If there is a new version available
-			if (Reloader.updateAvailable.get()) {
-
-				// Reset the new version flag
-				Reloader.updateAvailable.set(false);
-
-				// Set the refresh flag
-				localStorage.setItem('reloaderWasRefreshed', Date.now());
-
-				// Reload the page
-				window.location.replace(window.location.href);
-				
-			} else {
-
-				// Hide the splashscreen
-				navigator.splashscreen.hide();
-
-			}
-			
-
-		}, Reloader._options.checkTimer);
-
-
-	 // If we don't need to do an additional check
-	 } else {
-
-	  	 // Check if there's a new version available already AND we need to refresh on resume
-	  	 if ( Reloader.updateAvailable.get() && Reloader._options.refresh === 'startAndResume' ) {
-
-	  	 	// Show the splashscreen
-			navigator.splashscreen.show();
-
-	  	 	// Reset the new version flag
-			Reloader.updateAvailable.set(false);
-
-	  	 	// Set the refresh flag
-			localStorage.setItem('reloaderWasRefreshed', Date.now());
-			
-			// Refresh
-			window.location.replace(window.location.href);
-
-	  	} 
-
-	 }
-
+	Reloader._onResume();
 }, false);
-
 
 
 // Watch for the device pausing
@@ -176,31 +218,7 @@ document.addEventListener("pause", function() {
 
 // Capture the reload 
 Reload._onMigrate(function (retry) {
-
-	if (Reloader._options.refreshInstantly) {
-
-		// Show the splashscreen
-		navigator.splashscreen.show();
-
-		// Set the refresh flag
-		localStorage.setItem('reloaderWasRefreshed', Date.now());
-
-		// Reload the page
-		window.location.replace(window.location.href);
-
-		// return [true, {}];
-
-	} else {
-
-		// Set the flag
-		Reloader.updateAvailable.set(true);
-
-		// Don't refresh yet
-		return false;
-
-	}
-	
-
+	Reloader._onMigrate();
 });
 
 
@@ -211,14 +229,5 @@ Template.registerHelper("updateAvailable", function() {
 
 // Update available event
 $(document).on('click', '[reloader-update]', function(event) {
-
-	// Show the splashscreen
-	navigator.splashscreen.show();
-
-	// Set the refresh flag
-	localStorage.setItem('reloaderWasRefreshed', Date.now());
-
-	// Reload the page
-	window.location.replace(window.location.href);
-
+	Reloader.reload();
 });

--- a/reloader.js
+++ b/reloader.js
@@ -222,5 +222,3 @@ $(document).on('click', '[reloader-update]', function(event) {
 	Reloader.reload();
 });
 
-
-export Reloader

--- a/reloader.js
+++ b/reloader.js
@@ -14,7 +14,6 @@ Reloader = {
 																					'start',
 																					'instantly')),
 			idleCutoff: Match.Optional(Match.Integer),
-			refreshInstantly: Match.Optional(Boolean),
 			launchScreenDelay: Match.Optional(Match.Integer),
 		});
 		
@@ -158,7 +157,7 @@ Reloader = {
 	},
 
 	_onMigrate() {
-		if (this._options.refreshInstantly) {
+		if (this._options.refresh === 'instantly') {
 
 			this.reload();
 

--- a/test
+++ b/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+meteor test-packages ./ --driver-package practicalmeteor:mocha


### PR DESCRIPTION
Not ready to merge, I haven't tested yet. Probably even has syntax errors 😜 

Changes are more intelligible if you look at individual commits.
- In general when I've seen calling something not production-ready, it's sort of a vague unsubstantiated insult. Like the big firm that told me Meteor 0.9 wasn't production ready. Of course it was. So I think it's better to instead say why you're better, and that's more options and launch screen UX.
- tells them what they can do with pkg before getting into api
- ToC
- get them to use `Reloader.reload()` so we can keep `reloaderWasRefreshed` accurate.
- `launchScreenDelay`
- moved functions into Reloader for semantics and ability to use `this`, and now it's easier to see what's going on at the top level at the bottom of the file
- minor DRYing
- i'd recommend being more sparing with comments, in favor of writing readable code 😊 for example, i believe this:

``` javascript
// Hold the launch screen
const handle = LaunchScreen.hold();

// Just release the splash screen
handle.release();
```

takes longer to read and understand than this:

``` javascript
const launchScreen = LaunchScreen.hold();

launchScreen.release();
```

a lot of readbility has to do with naming and structure (`handle` -> `launchScreen`). similarly, note how I extracted out pieces of code, or compound booleans, into functions with names that were descriptive enough that no comment was necessary. 
