### PR TITLE
fix splash screen bug and update splash screen package

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'jamielob:reloader',
-  version: '1.2.2',
+  version: '1.2.3',
   summary: 'More control over hot code push reloading',
   git: 'https://github.com/jamielob/reloader/',
   documentation: 'README.md'

--- a/package.js
+++ b/package.js
@@ -7,7 +7,7 @@ Package.describe({
 });
 
 Cordova.depends({
-  'cordova-plugin-splashscreen': '3.2.1'
+  'cordova-plugin-splashscreen': '4.0.0'
 });
 
 Package.onUse(function(api) {

--- a/reloader.js
+++ b/reloader.js
@@ -93,6 +93,7 @@ Reloader = {
         }
 
         launchScreen.release();
+        navigator.splashscreen.hide();
 
       }
 


### PR DESCRIPTION
Dear @jamielob 

we have encountered an bug using this package. As soon as the app runs into idle status but there is no new update the user is stuck inside the splashscreen as the package runs `navigator.splashscreen.show()` on resume. However there is no reason for the splashscreen to disappear if there is no update. `_checkForUpdate`  will just run `_waitForUpdate`  and this will lead to `launchScreen.release()`. I have added `navigator.splashscreen.hide()` to fix the problem. Normally the splashscreen should be removed on deviceready but i dont think the event is triggered on an resume.

Would be great to get some feedback. I have also updated the splashscreen to 4.0.0 - if the [releasenotes](https://github.com/apache/cordova-plugin-splashscreen/blob/master/RELEASENOTES.md) are correct there are only some bugfixes.

PS.: To test it we have changed the settings to `idleCutoff: 1000` 
